### PR TITLE
feat: add shop logo upload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ const defaultProcessingSettings: ProcessingSettings = {
   defaultDpi: 600,
   dpiOverrides: {},
   shopName: '',
+  shopLogoDataUrl: null,
 };
 
 const navigationConfig: NavigationItem[] = [
@@ -132,10 +133,17 @@ function App() {
 
 
   useEffect(() => {
-    if (processingSettings.shopName === undefined) {
-      setProcessingSettings((prev) => ({ ...prev, shopName: '' }));
+    if (
+      processingSettings.shopName === undefined ||
+      processingSettings.shopLogoDataUrl === undefined
+    ) {
+      setProcessingSettings((prev) => ({
+        ...prev,
+        shopName: prev.shopName ?? '',
+        shopLogoDataUrl: prev.shopLogoDataUrl ?? null,
+      }));
     }
-  }, [processingSettings.shopName, setProcessingSettings]);
+  }, [processingSettings.shopLogoDataUrl, processingSettings.shopName, setProcessingSettings]);
 
   useEffect(() => {
     if (!watermarkSettings.enabled) {
@@ -451,6 +459,7 @@ function App() {
     try {
       pdfBytes = await generateInstructionsPdf({
         shopName: processingSettings.shopName,
+        shopLogoDataUrl: processingSettings.shopLogoDataUrl ?? null,
         artTitle,
         downloadLink,
         ratios: ratioSummaries,
@@ -507,6 +516,7 @@ function App() {
     croppedImages,
     downloadLink,
     processingSettings.shopName,
+    processingSettings.shopLogoDataUrl,
   ]);
 
   const openPreviewAt = useCallback((index: number) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,8 @@ export interface ProcessingSettings {
   dpiOverrides: Record<string, number>;
   // Shop name prefix appended to output filenames (no spaces)
   shopName: string;
+  // Optional data URL representing the shop logo for branded documents
+  shopLogoDataUrl: string | null;
 }
 
 export interface SourceImageInfo {


### PR DESCRIPTION
## Summary
- add persistent shop logo storage to processing settings defaults
- extend the shop branding panel with PNG/JPEG upload, preview, and removal controls
- display the optional logo beside the shop name in the generated instructions PDF header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9e50cb7548326bcded95838c063d4