### PR TITLE
feat: customize PDF instructions messaging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,9 @@ const defaultProcessingSettings: ProcessingSettings = {
   dpiOverrides: {},
   shopName: '',
   shopLogoDataUrl: null,
+  instructionsFooterTagline: '',
+  instructionsThankYouMessage:
+    'Thank you for supporting Sacred Realms Studio. Your purchase nurtures immersive art for mindful, modern sanctuaries.\nWith gratitude, The Sacred Realms Studio team',
 };
 
 const navigationConfig: NavigationItem[] = [
@@ -134,17 +137,30 @@ function App() {
 
 
   useEffect(() => {
-    if (
-      processingSettings.shopName === undefined ||
-      processingSettings.shopLogoDataUrl === undefined
-    ) {
-      setProcessingSettings((prev) => ({
-        ...prev,
-        shopName: prev.shopName ?? '',
-        shopLogoDataUrl: prev.shopLogoDataUrl ?? null,
-      }));
-    }
-  }, [processingSettings.shopLogoDataUrl, processingSettings.shopName, setProcessingSettings]);
+    setProcessingSettings((prev) => {
+      const next = { ...prev } as ProcessingSettings;
+      let changed = false;
+
+      if (prev.shopName === undefined) {
+        next.shopName = '';
+        changed = true;
+      }
+      if (prev.shopLogoDataUrl === undefined) {
+        next.shopLogoDataUrl = null;
+        changed = true;
+      }
+      if (prev.instructionsFooterTagline === undefined) {
+        next.instructionsFooterTagline = defaultProcessingSettings.instructionsFooterTagline;
+        changed = true;
+      }
+      if (prev.instructionsThankYouMessage === undefined) {
+        next.instructionsThankYouMessage = defaultProcessingSettings.instructionsThankYouMessage;
+        changed = true;
+      }
+
+      return changed ? next : prev;
+    });
+  }, [setProcessingSettings]);
 
   useEffect(() => {
     if (!watermarkSettings.enabled) {
@@ -483,6 +499,8 @@ function App() {
         downloadLink,
         ratios: ratioSummaries,
         previewImageDataUrl: previewCandidate?.dataUrl ?? null,
+        footerTagline: processingSettings.instructionsFooterTagline,
+        thankYouMessage: processingSettings.instructionsThankYouMessage,
       });
     } catch (pdfError) {
       console.error('Error creating instructions PDF:', pdfError);
@@ -534,8 +552,10 @@ function App() {
     artTitle,
     croppedImages,
     downloadLink,
-    processingSettings.shopName,
+    processingSettings.instructionsFooterTagline,
+    processingSettings.instructionsThankYouMessage,
     processingSettings.shopLogoDataUrl,
+    processingSettings.shopName,
   ]);
 
   const openPreviewAt = useCallback((index: number) => {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -37,6 +37,8 @@ export function SettingsPage({
   const filenameExampleParts = [sanitizedShopName || 'shop', 'portrait', '8x10_wm'];
   const filenameExample = filenameExampleParts.filter(Boolean).join('_');
   const shopLogoDataUrl = processingSettings.shopLogoDataUrl ?? null;
+  const footerTagline = processingSettings.instructionsFooterTagline ?? '';
+  const thankYouMessage = processingSettings.instructionsThankYouMessage ?? '';
 
   const handleShopNameChange = (value: string) => {
     const sanitized = value.replace(/\s+/g, '');
@@ -82,6 +84,14 @@ export function SettingsPage({
 
   const handleClearShopLogo = () => {
     onProcessingChange({ ...processingSettings, shopLogoDataUrl: null });
+  };
+
+  const handleFooterTaglineChange = (value: string) => {
+    onProcessingChange({ ...processingSettings, instructionsFooterTagline: value });
+  };
+
+  const handleThankYouMessageChange = (value: string) => {
+    onProcessingChange({ ...processingSettings, instructionsThankYouMessage: value });
   };
 
   return (
@@ -197,9 +207,48 @@ export function SettingsPage({
             className="block w-full text-sm text-slate-200 file:mr-4 file:rounded-lg file:border-0 file:bg-purple-500/70 file:px-4 file:py-2 file:font-semibold file:text-slate-100 hover:file:bg-purple-500/60"
           />
         </div>
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-slate-200" htmlFor="pdf-footer-tagline">
+            PDF footer tagline
+          </label>
+          <input
+            id="pdf-footer-tagline"
+            type="text"
+            value={footerTagline}
+            onChange={(event) => handleFooterTaglineChange(event.target.value)}
+            className={`${theme.input} w-full rounded-xl px-4 py-2 transition-colors duration-200`}
+            placeholder="Optional. Example: Curated prints for calm spaces"
+          />
+          <p className={`${theme.subheading} text-xs`}>
+            Leave blank to display only your shop name in the PDF footer.
+          </p>
+        </div>
       </Panel>
 
       <WatermarkSettingsForm settings={{ ...watermarkSettings, enabled: true }} onChange={onWatermarkChange} />
+
+      <Panel
+        title="PDF messaging"
+        description="Customize the closing note that appears at the end of the instructions PDF."
+      >
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-slate-200" htmlFor="pdf-thank-you-message">
+            Thank-you message
+          </label>
+          <textarea
+            id="pdf-thank-you-message"
+            rows={5}
+            value={thankYouMessage}
+            onChange={(event) => handleThankYouMessageChange(event.target.value)}
+            className={`${theme.input} w-full rounded-xl px-4 py-3 transition-colors duration-200 min-h-[140px]`}
+            placeholder="Share a personalized note of gratitude with your customers."
+          />
+          <p className={`${theme.subheading} text-xs`}>
+            Use line breaks to create separate paragraphs. This text replaces the default gratitude copy in the PDF.
+          </p>
+        </div>
+      </Panel>
 
       <OutputSettings settings={processingSettings} onChange={onProcessingChange} />
     </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,6 +55,10 @@ export interface ProcessingSettings {
   shopName: string;
   // Optional data URL representing the shop logo for branded documents
   shopLogoDataUrl: string | null;
+  // Optional tagline displayed beneath the shop name in the PDF footer
+  instructionsFooterTagline: string;
+  // Customizable closing copy shown at the end of the instructions PDF
+  instructionsThankYouMessage: string;
 }
 
 export interface SourceImageInfo {


### PR DESCRIPTION
## Summary
- add configurable PDF footer tagline and thank-you message settings
- update PDF generator to use shop branding, optional tagline, and remove hard-coded copy
- ensure processing defaults populate new messaging fields for PDF generation

## Testing
- npm run build *(fails: Rollup cannot resolve piexifjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ca08cb4698832690109b70d85a7175