### PR TITLE
fix(exif): add unicode-friendly copyright metadata

### DIFF
--- a/src/utils/exifUtils.ts
+++ b/src/utils/exifUtils.ts
@@ -17,6 +17,42 @@ const SOFTWARE_LABEL = 'Etsy Digital Art Packager';
 
 const JPEG_DATA_URL_PREFIX = /^data:image\/jpe?g;base64,/i;
 
+function sanitizeExifAscii(value: string): string {
+  return value
+    .replace(/[–—]/g, '-')
+    .replace(/©/g, '(c)')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\x20-\x7E]+/g, ' ')
+    .trim();
+}
+
+function encodeUtf16Le(value: string | null | undefined): number[] | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const bytes: number[] = [];
+  for (let i = 0; i < trimmed.length; i += 1) {
+    const codeUnit = trimmed.charCodeAt(i);
+    bytes.push(codeUnit & 0xff, codeUnit >> 8);
+  }
+  bytes.push(0, 0);
+  return bytes;
+}
+
+function setUnicodeTag(target: Record<number, unknown>, tag: number, value: string | null | undefined) {
+  const encoded = encodeUtf16Le(value);
+  if (encoded) {
+    target[tag] = encoded;
+  }
+}
+
 export function embedExifMetadata(dataUrl: string, options: EmbedExifOptions): string {
   if (!dataUrl || !JPEG_DATA_URL_PREFIX.test(dataUrl)) {
     return dataUrl;
@@ -35,30 +71,63 @@ export function embedExifMetadata(dataUrl: string, options: EmbedExifOptions): s
   const trimmedShopName = (shopName ?? '').trim();
   const trimmedTitle = (artTitle ?? '').trim();
   const normalizedVariant = variant === 'watermarked' || variant === 'final' ? variant : undefined;
+  const normalizedLicense = (licenseText ?? DEFAULT_LICENSE_TEXT).trim() || DEFAULT_LICENSE_TEXT;
+
+  const asciiShopName = sanitizeExifAscii(trimmedShopName);
+  const asciiTitle = sanitizeExifAscii(trimmedTitle);
+  const asciiLicense = sanitizeExifAscii(normalizedLicense);
+  const licenseCommentAscii = `License: ${asciiLicense || normalizedLicense}`;
+  const licenseCommentUnicode = `License: ${normalizedLicense}`;
+  const variantLabel =
+    normalizedVariant === 'watermarked'
+      ? 'Watermarked export'
+      : normalizedVariant === 'final'
+        ? 'Final export'
+        : undefined;
 
   const zeroth: Record<number, unknown> = {};
   const exif: Record<number, unknown> = {};
 
   if (trimmedShopName) {
-    zeroth[piexif.ImageIFD.Artist] = trimmedShopName;
+    if (asciiShopName) {
+      zeroth[piexif.ImageIFD.Artist] = asciiShopName;
+    }
+    setUnicodeTag(zeroth, piexif.ImageIFD.XPAuthor, trimmedShopName);
   }
 
   const copyrightSegments: string[] = [];
+  const copyrightSegmentsAscii: string[] = [];
   if (trimmedShopName) {
     copyrightSegments.push(`© ${trimmedShopName}`);
+    copyrightSegmentsAscii.push(`(c) ${asciiShopName || trimmedShopName}`);
   }
-  copyrightSegments.push(`License: ${licenseText}`);
-  zeroth[piexif.ImageIFD.Copyright] = copyrightSegments.join(' – ');
+  copyrightSegments.push(licenseCommentUnicode);
+  copyrightSegmentsAscii.push(licenseCommentAscii);
+  zeroth[piexif.ImageIFD.Copyright] = copyrightSegmentsAscii.join(' - ');
+  setUnicodeTag(zeroth, piexif.ImageIFD.XPCopyright, copyrightSegments.join(' – '));
 
-  const descriptionSegments: string[] = [];
+  const descriptionSegmentsAscii: string[] = [];
+  const descriptionSegmentsUnicode: string[] = [];
+  if (asciiTitle) {
+    descriptionSegmentsAscii.push(asciiTitle);
+  }
   if (trimmedTitle) {
-    descriptionSegments.push(trimmedTitle);
+    descriptionSegmentsUnicode.push(trimmedTitle);
   }
-  if (normalizedVariant) {
-    descriptionSegments.push(normalizedVariant === 'watermarked' ? 'Watermarked export' : 'Final export');
+  if (variantLabel) {
+    descriptionSegmentsAscii.push(variantLabel);
+    descriptionSegmentsUnicode.push(variantLabel);
   }
-  descriptionSegments.push(`License: ${licenseText}`);
-  zeroth[piexif.ImageIFD.ImageDescription] = descriptionSegments.join(' | ');
+  descriptionSegmentsAscii.push(licenseCommentAscii);
+  descriptionSegmentsUnicode.push(licenseCommentUnicode);
+
+  zeroth[piexif.ImageIFD.ImageDescription] = descriptionSegmentsAscii.join(' | ');
+  if (asciiTitle) {
+    zeroth[piexif.ImageIFD.DocumentName] = asciiTitle;
+  }
+  setUnicodeTag(zeroth, piexif.ImageIFD.XPTitle, trimmedTitle);
+  setUnicodeTag(zeroth, piexif.ImageIFD.XPSubject, variantLabel);
+  setUnicodeTag(zeroth, piexif.ImageIFD.XPComment, descriptionSegmentsUnicode.join(' | '));
 
   zeroth[piexif.ImageIFD.Software] = SOFTWARE_LABEL;
 
@@ -81,7 +150,7 @@ export function embedExifMetadata(dataUrl: string, options: EmbedExifOptions): s
     zeroth[piexif.ImageIFD.ImageLength] = roundedHeight;
   }
 
-  exif[piexif.ExifIFD.UserComment] = `License: ${licenseText}`;
+  exif[piexif.ExifIFD.UserComment] = licenseCommentAscii;
 
   const exifPayload = {
     '0th': zeroth,


### PR DESCRIPTION
## Summary
- sanitize strings before embedding and add UTF-16 helpers for XP metadata tags
- write copyright, title, variant, and license details to both ASCII and XP EXIF fields

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca2d2646c883268e75d754f287908a